### PR TITLE
[REFACTOR] Move step arguments from __init__ to __call__

### DIFF
--- a/baikal/_core/utils.py
+++ b/baikal/_core/utils.py
@@ -30,9 +30,6 @@ def make_args_from_attrs(obj, attrs):
     args = []
     for attr in attrs:
         attr_value = getattr(obj, attr)
-        if attr == "function":
-            # Used for Step's function argument
-            attr_value = getattr(attr_value, "__name__", None)
         arg = repr(attr_value)
         args.append("{}={}".format(attr, arg))
     return ", ".join(args)

--- a/baikal/steps/factory.py
+++ b/baikal/steps/factory.py
@@ -31,13 +31,9 @@ def make_step(base_class):
 
     """
 
-    def __init__(self, name=None, function=None, n_outputs=1, trainable=True, **kwargs):
+    def __init__(self, name=None, n_outputs=1, **kwargs):
         super(self.__class__, self).__init__(
-            name=name,
-            function=function,
-            n_outputs=n_outputs,
-            trainable=trainable,
-            **kwargs,
+            name=name, n_outputs=n_outputs, **kwargs,
         )
 
     metaclass = type(base_class)

--- a/baikal/steps/merge.py
+++ b/baikal/steps/merge.py
@@ -7,7 +7,7 @@ class Concatenate(Step):
     """Step for numpy's concatenate function."""
 
     def __init__(self, axis=-1, name=None):
-        super().__init__(name=name, trainable=False)
+        super().__init__(name=name)
         self.axis = axis
 
     def transform(self, *Xs):
@@ -18,7 +18,7 @@ class Stack(Step):
     """Step for numpy's stack function."""
 
     def __init__(self, axis=-1, name=None):
-        super().__init__(name=name, trainable=False)
+        super().__init__(name=name)
         self.axis = axis
 
     def transform(self, *Xs):
@@ -29,7 +29,7 @@ class ColumnStack(Step):
     """Step for numpy's column_stack function."""
 
     def __init__(self, name=None):
-        super().__init__(name=name, trainable=False)
+        super().__init__(name=name)
 
     def transform(self, *Xs):
         return np.column_stack(Xs)
@@ -43,7 +43,7 @@ class Split(Step):
             n_outputs = len(indices_or_sections) + 1
         except TypeError:
             n_outputs = indices_or_sections
-        super().__init__(name=name, n_outputs=n_outputs, trainable=False)
+        super().__init__(name=name, n_outputs=n_outputs)
         self.indices_or_sections = indices_or_sections
         self.axis = axis
 

--- a/tests/_core/test_data_placeholder.py
+++ b/tests/_core/test_data_placeholder.py
@@ -7,11 +7,7 @@ def test_repr():
         def somefunc(self, X):
             pass
 
-    step = DummyStep(name="some-step", function="somefunc")
+    step = DummyStep(name="some-step")
     data_placeholder = DataPlaceholder(step=step, name="some-step/0")
-    expected_repr = (
-        "DataPlaceholder(step=DummyStep(name='some-step', "
-        "function='somefunc', n_outputs=1, trainable=True), "
-        "name='some-step/0')"
-    )
+    expected_repr = "DataPlaceholder(step=DummyStep(name='some-step', n_outputs=1), name='some-step/0')"
     assert repr(data_placeholder) == expected_repr

--- a/tests/_core/test_step.py
+++ b/tests/_core/test_step.py
@@ -65,6 +65,10 @@ class TestStep:
             step = DummyStep()
             step(x, compute_func=None)
 
+        with pytest.raises(ValueError):
+            step = DummyStep()
+            step(x, compute_func=123)
+
         step = DummyStep()
         step(x, compute_func="somefunc")
         assert step.compute_func == step.somefunc
@@ -83,6 +87,15 @@ class TestStep:
         step = DummyStepWithTransform()
         step(x)
         assert step.compute_func == step.transform
+
+    def test_call_with_invalid_input_type(self, teardown):
+        with pytest.raises(ValueError):
+            LogisticRegression()([[1, 2], [3, 4]])
+
+    def test_call_with_invalid_target_type(self, teardown):
+        x = Input()
+        with pytest.raises(ValueError):
+            LogisticRegression()(x, [0, 1])
 
     # Below tests are parametrized to take two kind of fittable steps:
     # - step that requires y (e.g. Logistic Regression)

--- a/tests/steps/test_expression.py
+++ b/tests/steps/test_expression.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -8,11 +10,11 @@ from tests.helpers.fixtures import teardown
 
 
 def test_lambda(teardown):
-    def function(x1, x2, p1, p2=1):
+    def compute_func(x1, x2, p1, p2=1):
         return p1 * x1, x2 / p2
 
     x = Input()
-    y1, y2 = Lambda(function, n_outputs=2, p1=2, p2=2)([x, x])
+    y1, y2 = Lambda(partial(compute_func, p1=2, p2=2), n_outputs=2)([x, x])
     model = Model(x, [y1, y2])
 
     x_data = np.array([[1.0, 2.0], [3.0, 4.0]])


### PR DESCRIPTION
This is to pave the road for shareable steps. A shared step needs to specify different behavior depending on where it is called, hence the need to pass the arguments that control this behavior (`compute_func` (formerly `function`) and `trainable`) at `__call__` time.