### PR TITLE
[BUGFIX] Use list args for multi inputs/targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,22 @@ class LogisticRegression(Step, sklearn.linear_model.LogisticRegression):
 
 Other steps are defined similarly (omitted here for brevity).
 
+**baikal** can also handle steps with multiple input/outputs/targets. The base class may implement a predict/transform method (the compute function) that take multiple inputs and returns multiple outputs, and a fit method that takes multiple inputs and targets (native scikit-learn classes at present take one input, return one output, and take at most one target). In this case, the input/target arguments are expected to be a list of (typically) array-like objects, and the compute function is expected to return a list of array-like objects. For example, the base class may implement the methods like this:
+
+```python
+class SomeClass(BaseEstimator):
+    ...
+    def predict(self, Xs):
+        X1, X2 = Xs
+        # use X1, X2 to calculate y1, y2
+        return y1, y2
+
+    def fit(self, Xs, ys):
+        (X1, X2), (y1, y2) = Xs, ys
+        # use X1, X2, y1, y2 to fit the model
+        return self
+```
+
 ### 2. Build the model
 
 Once we have defined the steps, we can make a model like shown below. First, you create the initial step, that serves as the entry-point to the model, by calling the `Input` helper function. This outputs a DataPlaceholder representing one of the inputs to the model. Then, all you have to do is to instantiate the steps and call them on the outputs (DataPlaceholders from previous steps) as you deem appropriate. Finally, you instantiate the model with the inputs/outputs (also DataPlaceholders) that specify your pipeline.

--- a/baikal/_core/model.py
+++ b/baikal/_core/model.py
@@ -6,7 +6,7 @@ from baikal._core.data_placeholder import is_data_placeholder_list, DataPlacehol
 from baikal._core.digraph import DiGraph
 from baikal._core.step import Step, InputStep, Node
 from baikal._core.typing import ArrayLike
-from baikal._core.utils import listify, safezip2, SimpleCache
+from baikal._core.utils import listify, safezip2, SimpleCache, unlistify
 
 # Just to avoid function signatures painful to the eye
 DataPlaceHolders = Union[DataPlaceholder, List[DataPlaceholder]]
@@ -412,7 +412,10 @@ class Model(Step):
                 fit_params = fit_params_steps.get(node.step, {})
 
                 # TODO: Add a try/except to catch missing output data errors (e.g. when forgot ensemble outputs)
-                node.step.fit(*Xs, *ys, **fit_params)
+                if ys:
+                    node.step.fit(unlistify(Xs), unlistify(ys), **fit_params)
+                else:
+                    node.step.fit(unlistify(Xs), **fit_params)
 
             # 2) predict/transform phase
             if list(self.graph.successors(node)):
@@ -486,7 +489,7 @@ class Model(Step):
         # This happens when recomputing a step that had a subset of its outputs already passed in the inputs.
         # TODO: Some regressors have extra options in their predict method, and they return a tuple of arrays.
         # https://scikit-learn.org/stable/glossary.html#term-predict
-        output_data = node.compute_func(*Xs)
+        output_data = node.compute_func(unlistify(Xs))
         output_data = listify(output_data)
 
         try:

--- a/baikal/_core/model.py
+++ b/baikal/_core/model.py
@@ -412,7 +412,7 @@ class Model(Step):
                 fit_params = fit_params_steps.get(node.step, {})
 
                 # TODO: Add a try/except to catch missing output data errors (e.g. when forgot ensemble outputs)
-                node.step.fit(*Xs, *ys, **fit_params)  # type: ignore # (it's a mixin)
+                node.step.fit(*Xs, *ys, **fit_params)
 
             # 2) predict/transform phase
             if list(self.graph.successors(node)):

--- a/baikal/_core/step.py
+++ b/baikal/_core/step.py
@@ -1,6 +1,6 @@
 import re
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 
 from baikal._core.data_placeholder import DataPlaceholder, is_data_placeholder_list
 from baikal._core.utils import listify, make_name, make_repr, make_args_from_attrs
@@ -363,6 +363,11 @@ class Step(_StepBase):
     >>> logreg = LogisticRegression(C=2.0)
     """
 
+    if TYPE_CHECKING:
+
+        def fit(self, X, y, **fit_params):
+            return self
+
     def __init__(self, *args, name: str = None, n_outputs: int = 1, **kwargs):
         # Necessary to use this class as a mixin
         super().__init__(*args, name=name, n_outputs=n_outputs, **kwargs)  # type: ignore
@@ -598,5 +603,4 @@ class Node:
 # Notes on typing:
 # mypy produces false positives with mixins, so we use type: ignore
 # See:
-# https://github.com/python/mypy/issues/1996
 # https://github.com/python/mypy/issues/5887

--- a/baikal/_core/step.py
+++ b/baikal/_core/step.py
@@ -319,6 +319,12 @@ class Step(_StepBase):
         2. In the class `__init__`, call `super().__init__(...)` and pass the
            appropriate step parameters.
 
+    The base class may implement a predict/transform method (the compute function)
+    that take multiple inputs and returns multiple outputs, and a fit method that
+    takes multiple inputs and targets. In this case, the input/target arguments are
+    expected to be a list of (typically) array-like objects, and the compute function
+    is expected to return a list of array-like objects.
+
     Parameters
     ----------
     name

--- a/baikal/_core/utils.py
+++ b/baikal/_core/utils.py
@@ -1,13 +1,21 @@
-from typing import Union, Any, List, Tuple
+from typing import Union, Any, List, Tuple, Sequence
 
 
-def listify(x: Union[Any, List[Any], Tuple[Any]]) -> List[Any]:
+def listify(x: Union[Any, List[Any], Tuple[Any, ...]]) -> List[Any]:
     if isinstance(x, list):
         pass
     elif isinstance(x, tuple):
         x = list(x)
     else:
         x = [x]
+    return x
+
+
+def unlistify(x: List[Any]) -> Union[List[Any], Any]:
+    if not isinstance(x, list):
+        raise ValueError("x must be a list.")
+    if len(x) == 1:
+        return x[0]
     return x
 
 

--- a/baikal/steps/expression.py
+++ b/baikal/steps/expression.py
@@ -13,9 +13,10 @@ class Lambda(Step):
     Parameters
     ----------
     compute_func
-        The function to make the step from. This function takes one or several input
-        data object as its first arguments. If compute_func takes additional arguments
-        you may either pass them as keyword arguments or use a functools.partial object.
+        The function to make the step from. This function a single array-like object
+        (in the case of a single input) or a list of array-like objects (in the case of
+        multiple inputs) If compute_func takes additional arguments you may either pass
+        them as keyword arguments or use a functools.partial object.
 
     n_outputs
         Number of outputs of the function.
@@ -29,7 +30,8 @@ class Lambda(Step):
 
     Examples
     --------
-    >>> def function(x1, x2):
+    >>> def function(Xs):
+    >>>     x1, x2 = Xs
     >>>     return 2 * x1, x2 / 2
     >>>
     >>> x = Input()

--- a/baikal/steps/merge.py
+++ b/baikal/steps/merge.py
@@ -10,7 +10,7 @@ class Concatenate(Step):
         super().__init__(name=name)
         self.axis = axis
 
-    def transform(self, *Xs):
+    def transform(self, Xs):
         return np.concatenate(Xs, axis=self.axis)
 
 
@@ -21,7 +21,7 @@ class Stack(Step):
         super().__init__(name=name)
         self.axis = axis
 
-    def transform(self, *Xs):
+    def transform(self, Xs):
         return np.stack(Xs, axis=self.axis)
 
 
@@ -31,7 +31,7 @@ class ColumnStack(Step):
     def __init__(self, name=None):
         super().__init__(name=name)
 
-    def transform(self, *Xs):
+    def transform(self, Xs):
         return np.column_stack(Xs)
 
 

--- a/tests/_core/test_utils.py
+++ b/tests/_core/test_utils.py
@@ -2,7 +2,13 @@ from contextlib import contextmanager
 
 import pytest
 
-from baikal._core.utils import listify, safezip2, find_duplicated_items, SimpleCache
+from baikal._core.utils import (
+    listify,
+    unlistify,
+    safezip2,
+    find_duplicated_items,
+    SimpleCache,
+)
 
 
 @contextmanager
@@ -13,6 +19,19 @@ def does_not_raise():
 @pytest.mark.parametrize("x,expected", [(1, [1]), ((1,), [1]), ([1], [1])])
 def test_listify(x, expected):
     assert listify(x) == expected
+
+
+@pytest.mark.parametrize(
+    "x,expected,raises",
+    [
+        ([1], 1, does_not_raise()),
+        ((1,), None, pytest.raises(ValueError)),
+        ([1, 2], [1, 2], does_not_raise()),
+    ],
+)
+def test_unlistify(x, expected, raises):
+    with raises:
+        assert unlistify(x) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/dummy_steps.py
+++ b/tests/helpers/dummy_steps.py
@@ -10,8 +10,8 @@ class DummySISO(Step):
     def __init__(self, name=None):
         super().__init__(name=name)
 
-    def transform(self, x):
-        return 2 * x
+    def transform(self, X):
+        return 2 * X
 
 
 class DummySIMO(Step):
@@ -21,8 +21,8 @@ class DummySIMO(Step):
     def __init__(self, name=None):
         super().__init__(name=name, n_outputs=2)
 
-    def transform(self, x):
-        return x + 1.0, x - 1.0
+    def transform(self, X):
+        return X + 1.0, X - 1.0
 
 
 class DummyMISO(Step):
@@ -32,8 +32,14 @@ class DummyMISO(Step):
     def __init__(self, name=None):
         super().__init__(name=name)
 
-    def transform(self, x1, x2):
+    def transform(self, Xs):
+        x1, x2 = Xs
         return x1 + x2
+
+    def fit(self, Xs, ys):
+        # Suppose that this dummy model expects two inputs and two targets
+        self.fitted_ = True
+        return self
 
 
 class DummyMIMO(Step):
@@ -43,7 +49,8 @@ class DummyMIMO(Step):
     def __init__(self, name=None):
         super().__init__(name=name, n_outputs=2)
 
-    def transform(self, x1, x2):
+    def transform(self, Xs):
+        x1, x2 = Xs
         return x1 * 10.0, x2 / 10.0
 
     def fit(self, X):
@@ -57,8 +64,8 @@ class DummyImproperlyDefined(Step):
     def __init__(self, name=None):
         super().__init__(name=name)
 
-    def transform(self, x):
-        return x + 1.0, x - 1.0
+    def transform(self, X):
+        return X + 1.0, X - 1.0
 
 
 class _DummyEstimator(BaseEstimator):

--- a/tests/steps/test_expression.py
+++ b/tests/steps/test_expression.py
@@ -8,7 +8,8 @@ from tests.helpers.fixtures import teardown
 
 
 def test_lambda(teardown):
-    def compute_func(x1, x2, p1, p2=1):
+    def compute_func(Xs, p1, p2=1):
+        x1, x2 = Xs
         return p1 * x1, x2 / p2
 
     x = Input()


### PR DESCRIPTION
Fix an API inconsistency regarding the handling of the arguments of fit/compute for steps with multiple inputs and targets. Before this fix the multiple inputs and targets would passed unpacked to the fit/compte (i.e. `step.fit(*Xs, *ys)`) which is inconsistent with the API of `Model` and thus impossible to use nested models with multiple inputs/targets.

With this fix steps that take multiple inputs/targets must have fit/compute methods similar to `Model`, i.e. either a single array-like object in the case of single input/target or a list of such objects in the case of multiple inputs/targets.