### PR TITLE
[ENH] fit_compute_func API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ upload-cov:
 
 type-check:
 	. venv/bin/activate; \
-	mypy --ignore-missing-imports --allow-redefinition baikal/ tests/
+	mypy --ignore-missing-imports baikal/ tests/
 
 wheel: clean venv
 	. venv/bin/activate; \

--- a/README.md
+++ b/README.md
@@ -410,6 +410,33 @@ model = Model(x, y_p, y_t)
 
 Click [here](examples/stacked_classifiers_naive.py) for a full example.
 
+### Stacked classifiers (standard protocol)
+
+In the naive stack above, each classifier in the 1st level will calculate the predictions for the 2nd level using the same data it used for fitting its parameters. This is prone to overfitting as the 2nd level classifier will tend to give more weight to an overfit classifier in the 1st level. To avoid this, the standard protocol recommends that, during fit, the 1st level classifiers are still trained on the original data, but instead they provide out-of-fold (OOF) predictions to the 2nd level classifier. To achieve this special behavior, we leverage the `fit_compute_func` API: we define a `fit_predict` method that does the fitting and the OOF predictions, and add it as a method of the 1st level classifiers (`LogisticRegression` and `RandomForestClassifier`, in the example below) when making the steps. **baikal** will then detect and use this method during fit.
+
+```python
+from sklearn.model_selection import cross_val_predict
+
+
+def fit_predict(self, X, y):
+    self.fit(X, y)
+    return cross_val_predict(self, X, y, method="predict_proba")
+
+
+attr_dict = {"fit_predict": fit_predict}
+
+# 1st level classifiers
+LogisticRegression = make_step(sklearn.linear_model.LogisticRegression, attr_dict)
+RandomForestClassifier = make_step(sklearn.ensemble.RandomForestClassifier, attr_dict)
+
+# 2nd level classifier
+ExtraTreesClassifier = make_step(sklearn.ensemble.ExtraTreesClassifier)
+
+# The rest of the stack is build exactly the same as in the naive example.
+```
+
+Click [here](examples/stacked_classifiers_standard.py) for a full example.
+
 ### Classifier chain
 
 The API also lends itself for more interesting configurations, such as that of [classifier chains](https://en.wikipedia.org/wiki/Classifier_chains). By leveraging the API and Python's own control flow, a classifier chain model can be built as follows:

--- a/README.md
+++ b/README.md
@@ -400,8 +400,8 @@ y_t = Input()
 y_p1 = LogisticRegression()(x, y_t, compute_func="predict_proba")
 y_p2 = RandomForestClassifier()(x, y_t, compute_func="predict_proba")
 # predict_proba returns arrays whose columns sum to one, so we drop one column
-y_p1 = Lambda(lambda array: array[:, :-1])(y_p1)
-y_p2 = Lambda(lambda array: array[:, :-1])(y_p2)
+y_p1 = Lambda(lambda array: array[:, 1:])(y_p1)
+y_p2 = Lambda(lambda array: array[:, 1:])(y_p2)
 ensemble_features = ColumnStack()([y_p1, y_p2])
 y_p = ExtraTreesClassifier()(ensemble_features, y_t)
 

--- a/README.md
+++ b/README.md
@@ -390,9 +390,9 @@ In order to use the plot utility, you need to install [pydot](https://pypi.org/p
 
 ## Examples
 
-### Stacked classifiers
+### Stacked classifiers (naive protocol)
 
-Similar to the the example in the quick-start above, stacks of classifiers (or regressors) can be built like shown below. Note that you can specify the function the step should use for computation, in this case `compute_func='predict_proba'` to use the label probabilities as the features of the meta-classifier.
+Similar to the the example in the quick-start above, (a naive) stacks of classifiers (or regressors) can be built like shown below. Note that you can specify the function the step should use for computation, in this case `compute_func='predict_proba'` to use the label probabilities as the features of the meta-classifier.
 
 ```python
 x = Input()
@@ -408,7 +408,7 @@ y_p = ExtraTreesClassifier()(ensemble_features, y_t)
 model = Model(x, y_p, y_t)
 ```
 
-Click [here](examples/stacked_classifiers.py) for a full example.
+Click [here](examples/stacked_classifiers_naive.py) for a full example.
 
 ### Classifier chain
 

--- a/baikal/_core/model.py
+++ b/baikal/_core/model.py
@@ -401,6 +401,15 @@ class Model(Step):
         results_cache.update(y_norm)
 
         for node in nodes:
+            # TODO: Add a step.current_port attribute.
+            # This attribute would be useful for introspection
+            # during graph runtime to know which port is currently
+            # under execution. This attribute can be used to choose
+            # the appropriate compute_func in fit_compute_func.
+            # The value would be always None when the graph is not
+            # running (i.e. executing Model.fit or Model.predict)
+            # and would be set to the appropriate value by the graph
+            # runtime via a context manager.
             Xs = [results_cache[i] for i in node.inputs]
             successors = list(self.graph.successors(node))
 

--- a/baikal/_core/model.py
+++ b/baikal/_core/model.py
@@ -416,12 +416,9 @@ class Model(Step):
                 continue
 
             # ----- default behavior
-            if hasattr(node.step, "fit"):
+            if node.fit_func is not None:
                 # TODO: Add a try/except to catch missing output data errors (e.g. when forgot ensemble outputs)
-                if ys:
-                    node.step.fit(unlistify(Xs), unlistify(ys), **fit_params)
-                else:
-                    node.step.fit(unlistify(Xs), **fit_params)
+                self._fit_step(node, Xs, ys, **fit_params)
 
             if list(self.graph.successors(node)):
                 self._compute_step(node, Xs, results_cache)
@@ -487,6 +484,13 @@ class Model(Step):
             return output_data[0]
         else:
             return output_data
+
+    @staticmethod
+    def _fit_step(node, Xs, ys, **fit_params):
+        if ys:
+            node.fit_func(unlistify(Xs), unlistify(ys), **fit_params)
+        else:
+            node.fit_func(unlistify(Xs), **fit_params)
 
     def _compute_step(self, node, Xs, cache):
         # TODO: Raise warning if computed output is already in cache.

--- a/baikal/_core/model.py
+++ b/baikal/_core/model.py
@@ -402,9 +402,10 @@ class Model(Step):
 
         for node in nodes:
             Xs = [results_cache[i] for i in node.inputs]
+            successors = list(self.graph.successors(node))
 
             if not node.trainable:
-                if list(self.graph.successors(node)):
+                if successors:
                     self._compute_node(node, Xs, results_cache)
                 continue
 
@@ -419,7 +420,7 @@ class Model(Step):
             if node.fit_func is not None:
                 self._fit_node(node, Xs, ys, **fit_params)
 
-            if list(self.graph.successors(node)):
+            if successors:
                 self._compute_node(node, Xs, results_cache)
 
         return self

--- a/baikal/_core/step.py
+++ b/baikal/_core/step.py
@@ -618,8 +618,6 @@ class Step(_StepBase):
             targets = []
 
         outputs = self._build_outputs()
-        compute_func = self._check_compute_func(compute_func)
-        fit_compute_func = self._check_fit_compute_func(fit_compute_func)
 
         self._nodes.append(
             Node(
@@ -627,8 +625,8 @@ class Step(_StepBase):
                 inputs,
                 outputs,
                 targets,
-                compute_func,
-                fit_compute_func,
+                self._check_compute_func(compute_func),
+                self._check_fit_compute_func(fit_compute_func),
                 trainable,
             )
         )

--- a/baikal/_core/step.py
+++ b/baikal/_core/step.py
@@ -381,7 +381,7 @@ class Step(_StepBase):
         self._nodes = []  # type: List[Node]
 
     def _check_compute_func(self, compute_func):
-        if compute_func is None:
+        if compute_func == "auto":
             if hasattr(self, "predict"):
                 compute_func = self.predict
             elif hasattr(self, "transform"):
@@ -407,7 +407,7 @@ class Step(_StepBase):
         inputs: Union[DataPlaceholder, List[DataPlaceholder]],
         targets: Optional[Union[DataPlaceholder, List[DataPlaceholder]]] = None,
         *,
-        compute_func: Optional[Union[str, Callable[..., Any]]] = None,
+        compute_func: Union[str, Callable[..., Any]] = "auto",
         trainable: bool = True,
     ) -> Union[DataPlaceholder, List[DataPlaceholder]]:
         """Call the step on input(s) (from previous steps) and generates the
@@ -430,7 +430,7 @@ class Step(_StepBase):
 
         compute_func
             Specifies which function must be used when computing the step during
-            the model graph execution. If None (default), it will use the predict
+            the model graph execution. If "auto" (default), it will use the predict
             or the transform method (in that order). If a name string is passed,
             it will use the method that matches the given name. If a callable is
             passed, it will use that callable when computing the step.

--- a/baikal/_core/step.py
+++ b/baikal/_core/step.py
@@ -398,7 +398,8 @@ class Step(_StepBase):
                 pass
             else:
                 raise ValueError(
-                    "If specified, `function` must be either a " "string or a callable."
+                    "If specified, `compute_func` must be either a "
+                    "string or a callable."
                 )
         return compute_func
 
@@ -430,8 +431,8 @@ class Step(_StepBase):
 
         compute_func
             Specifies which function must be used when computing the step during
-            the model graph execution. If "auto" (default), it will use the predict
-            or the transform method (in that order). If a name string is passed,
+            the model graph execution. If `"auto"` (default), it will use the `predict`
+            or the `transform `method (in that order). If a name string is passed,
             it will use the method that matches the given name. If a callable is
             passed, it will use that callable when computing the step.
 

--- a/baikal/_core/step.py
+++ b/baikal/_core/step.py
@@ -170,6 +170,43 @@ class _StepBase:
         self._set_step_attr("compute_func", value)
 
     @property
+    def fit_compute_func(self) -> Optional[Callable]:
+        """Get the fit-compute function of the step.
+
+        You can use this only when the step has been called exactly once.
+
+        Returns
+        -------
+        Callable
+
+        Raises
+        ------
+        AttributeError
+            If the step has not been called yet or it is a shared step
+            (called several times).
+        """
+        return self._get_step_attr("fit_compute_func")
+
+    @fit_compute_func.setter
+    def fit_compute_func(self, value: Optional[Callable]):
+        """Set the fit-compute function of the step.
+
+        You can use this only when the step has been called exactly once.
+
+        Parameters
+        ----------
+        value
+            fit-compute function of the step. Pass `None` to disable it.
+
+        Raises
+        ------
+        AttributeError
+            If the step has not been called yet or it is a shared step
+            (called several times).
+        """
+        self._set_step_attr("fit_compute_func", value)
+
+    @property
     def trainable(self) -> bool:
         """Get trainable flag of the step.
 
@@ -274,6 +311,33 @@ class _StepBase:
             Compute function of the step.
         """
         self._nodes[port].compute_func = value
+
+    def get_fit_compute_func_at(self, port: int) -> Optional[Callable]:
+        """Get fit-compute function at the specified port.
+
+        Parameters
+        ----------
+        port
+            Port from which to get the fit-compute function.
+
+        Returns
+        -------
+        Callable or None
+        """
+        return self._nodes[port].fit_compute_func
+
+    def set_fit_compute_func_at(self, port: int, value: Optional[Callable]):
+        """Set fit-compute function at the specified port.
+
+        Parameters
+        ----------
+        port
+            Port on which to set the fit-compute function.
+
+        value
+            fit-compute function of the step. Pass `None` to disable it.
+        """
+        self._nodes[port].fit_compute_func = value
 
     def get_trainable_at(self, port: int) -> bool:
         """Get trainable flag at the specified port.
@@ -403,12 +467,34 @@ class Step(_StepBase):
                 )
         return compute_func
 
+    def _check_fit_compute_func(self, fit_compute_func):
+        if fit_compute_func == "auto":
+            if hasattr(self, "fit_predict"):
+                fit_compute_func = self.fit_predict
+            elif hasattr(self, "fit_transform"):
+                fit_compute_func = self.fit_transform
+            else:
+                fit_compute_func = None
+        else:
+            if isinstance(fit_compute_func, str):
+                fit_compute_func = getattr(self, fit_compute_func)
+            elif callable(fit_compute_func):
+                pass
+            elif fit_compute_func is None:
+                pass
+            else:
+                raise ValueError(
+                    "If specified, `fit_compute_func` must be either None, a string or a callable."
+                )
+        return fit_compute_func
+
     def __call__(
         self,
         inputs: Union[DataPlaceholder, List[DataPlaceholder]],
         targets: Optional[Union[DataPlaceholder, List[DataPlaceholder]]] = None,
         *,
         compute_func: Union[str, Callable[..., Any]] = "auto",
+        fit_compute_func: Optional[Union[str, Callable[..., Any]]] = "auto",
         trainable: bool = True,
     ) -> Union[DataPlaceholder, List[DataPlaceholder]]:
         """Call the step on input(s) (from previous steps) and generates the
@@ -440,9 +526,37 @@ class Step(_StepBase):
             step (this is not checked, but will raise an error during graph
             execution if there is a mismatch).
 
-            scikit-learn classes typically implement a predict method (Estimators)
-            or a transform method (Transformers), but with this argument you can,
+            scikit-learn classes typically implement a `predict` method (Estimators)
+            or a `transform` method (Transformers), but with this argument you can,
             for example, specify `predict_proba` as the compute function.
+
+        fit_compute_func
+            Specifies which function must be used when fitting AND computing the step
+            during the model graph execution.
+
+            If `"auto"` (default), it will use the `fit_predict` or the `fit_transform`
+            method (in that order) if they are implemented, otherwise it will be
+            disabled. If a name string is passed, it will use the method that matches
+            the given name. If a callable is passed, it will use that callable when
+            fitting the step. If `None` is passed it will be ignored during graph
+            execution.
+
+            The number of inputs, outputs and targets, of the function must match those
+            of the step (this is not checked, but will raise an error during graph
+            execution if there is a mismatch).
+
+            By default, when a model is fit, the graph engine will for each step
+            1) execute `fit` to fit the step, and then 2) execute `compute_func` to
+            compute the outputs required by successor steps. If a step specifies a
+            `fit_compute_func`, the graph execution will use that instead to fit and
+            compute the outputs in a single call. This can be useful for
+
+            1. leveraging implementations of `fit_transform` that are more efficient
+                than calling `fit` and `transform` separately,
+            2. using transductive estimators,
+            3. implementing training protocols such as that of stacked classifiers,
+                where the classifier in the first stage might compute out-of-fold
+                predictions.
 
         trainable
             Whether the step is trainable (True) or not (False). This flag is only
@@ -505,9 +619,18 @@ class Step(_StepBase):
 
         outputs = self._build_outputs()
         compute_func = self._check_compute_func(compute_func)
+        fit_compute_func = self._check_fit_compute_func(fit_compute_func)
 
         self._nodes.append(
-            Node(self, inputs, outputs, targets, compute_func, trainable)
+            Node(
+                self,
+                inputs,
+                outputs,
+                targets,
+                compute_func,
+                fit_compute_func,
+                trainable,
+            )
         )
 
         if self._n_outputs == 1:
@@ -559,7 +682,9 @@ class InputStep(_StepBase):
     def __init__(self, name=None):
         super().__init__(name=name, n_outputs=1)
         self._nodes = [
-            Node(self, [], [DataPlaceholder(self, 0, self._name)], [], None, False)
+            Node(
+                self, [], [DataPlaceholder(self, 0, self._name)], [], None, None, False
+            )
         ]
 
     def __repr__(self):
@@ -597,6 +722,7 @@ class Node:
         outputs: List[DataPlaceholder],
         targets: List[DataPlaceholder],
         compute_func: Callable,
+        fit_compute_func: Optional[Callable],
         trainable: bool,
     ):
         self.step = step
@@ -604,6 +730,7 @@ class Node:
         self.outputs = outputs
         self.targets = targets
         self.compute_func = compute_func
+        self.fit_compute_func = fit_compute_func
         self.trainable = trainable
 
 

--- a/baikal/steps/expression.py
+++ b/baikal/steps/expression.py
@@ -66,6 +66,7 @@ class Lambda(Step):
         targets: Optional[Union[DataPlaceholder, List[DataPlaceholder]]] = None,
         *,
         compute_func: Union[str, Callable[..., Any]] = "auto",
+        fit_compute_func: Optional[Union[str, Callable[..., Any]]] = "auto",
         trainable: bool = True,
     ) -> Union[DataPlaceholder, List[DataPlaceholder]]:
         """Call the step on input(s) (from previous steps) and generates the

--- a/baikal/steps/expression.py
+++ b/baikal/steps/expression.py
@@ -65,7 +65,7 @@ class Lambda(Step):
         inputs: Union[DataPlaceholder, List[DataPlaceholder]],
         targets: Optional[Union[DataPlaceholder, List[DataPlaceholder]]] = None,
         *,
-        compute_func: Optional[Union[str, Callable[..., Any]]] = None,
+        compute_func: Union[str, Callable[..., Any]] = "auto",
         trainable: bool = True,
     ) -> Union[DataPlaceholder, List[DataPlaceholder]]:
         """Call the step on input(s) (from previous steps) and generates the

--- a/baikal/steps/factory.py
+++ b/baikal/steps/factory.py
@@ -3,7 +3,7 @@ import inspect
 from baikal import Step
 
 
-def make_step(base_class):
+def make_step(base_class, attr_dict=None):
     """Creates a step subclass from the given base class.
 
     For example, calling
@@ -21,10 +21,16 @@ def make_step(base_class):
     base_class : type
         The base class to inherit from. It must implement the scikit-learn API.
 
+    attr_dict : dict
+        Dictionary of additional attributes for the class. You can use this to add
+        methods such as `fit_compute` to the class. (keys: name of attribute (str),
+        values: attributes).
+
     Returns
     -------
     step_subclass: type
-        A new class that inherits from both Step and the given base class.
+        A new class that inherits from both Step and the given base class and has the
+        the specified attributes.
 
     """
 
@@ -37,7 +43,11 @@ def make_step(base_class):
     name = base_class.__name__
     bases = (Step, base_class)
     caller_module = inspect.currentframe().f_back.f_globals["__name__"]
+
     dict = {"__init__": __init__, "__module__": caller_module}
+    if attr_dict is not None:
+        dict.update(attr_dict)
+
     step_subclass = metaclass(name, bases, dict)
 
     return step_subclass

--- a/examples/stacked_classifiers.py
+++ b/examples/stacked_classifiers.py
@@ -24,13 +24,15 @@ X_train, X_test, y_train, y_test = train_test_split(
 # ------- Build model
 x = Input()
 y_t = Input()
-y_p1 = LogisticRegression(solver="liblinear")(x, y_t, compute_func="predict_proba")
-y_p2 = RandomForestClassifier()(x, y_t, compute_func="predict_proba")
+y_p1 = LogisticRegression(solver="liblinear", random_state=0)(
+    x, y_t, compute_func="predict_proba"
+)
+y_p2 = RandomForestClassifier(random_state=0)(x, y_t, compute_func="predict_proba")
 # predict_proba returns arrays whose columns sum to one, so we drop one column
-y_p1 = Lambda(lambda array: array[:, :-1])(y_p1)
-y_p2 = Lambda(lambda array: array[:, :-1])(y_p2)
+y_p1 = Lambda(lambda array: array[:, 1:])(y_p1)
+y_p2 = Lambda(lambda array: array[:, 1:])(y_p2)
 stacked_features = ColumnStack()([y_p1, y_p2])
-y_p = ExtraTreesClassifier()(stacked_features, y_t)
+y_p = ExtraTreesClassifier(random_state=0)(stacked_features, y_t)
 
 model = Model(x, y_p, y_t)
 plot_model(model, filename="stacked_classifiers.png", dpi=96)

--- a/examples/stacked_classifiers_naive.py
+++ b/examples/stacked_classifiers_naive.py
@@ -35,7 +35,7 @@ stacked_features = ColumnStack()([y_p1, y_p2])
 y_p = ExtraTreesClassifier(random_state=0)(stacked_features, y_t)
 
 model = Model(x, y_p, y_t)
-plot_model(model, filename="stacked_classifiers.png", dpi=96)
+plot_model(model, filename="stacked_classifiers_naive.png", dpi=96)
 
 # ------- Train model
 model.fit(X_train, y_train)

--- a/examples/stacked_classifiers_standard.py
+++ b/examples/stacked_classifiers_standard.py
@@ -1,0 +1,64 @@
+import sklearn.datasets
+import sklearn.ensemble
+import sklearn.linear_model
+from sklearn.metrics import f1_score
+from sklearn.model_selection import cross_val_predict, train_test_split
+
+from baikal import Input, Model, make_step
+from baikal.plot import plot_model
+from baikal.steps import ColumnStack, Lambda
+
+
+# ------- Define steps
+# During fit, the 1st level classifiers must be trained on the original data, but must
+# provide out-of-fold (OOF) predictions to the 2nd level classifier. To achieve this we
+# leverage the fit_compute_func API to configure this behavior. In this case we define
+# a fit_predict method that does the fitting and the OOF predictions, and add it as a
+# method of the 1st level classifiers (LogisticRegression and RandomForestClassifier)
+# when making the steps. baikal will then detect and use this method during fit.
+
+
+def fit_predict(self, X, y):
+    self.fit(X, y)
+    return cross_val_predict(self, X, y, method="predict_proba")
+
+
+attr_dict = {"fit_predict": fit_predict}
+LogisticRegression = make_step(sklearn.linear_model.LogisticRegression, attr_dict)
+RandomForestClassifier = make_step(sklearn.ensemble.RandomForestClassifier, attr_dict)
+ExtraTreesClassifier = make_step(sklearn.ensemble.ExtraTreesClassifier)
+
+# ------- Load dataset
+data = sklearn.datasets.load_breast_cancer()
+X, y_p = data.data, data.target
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y_p, test_size=0.2, random_state=0
+)
+
+# ------- Build model
+# The model is built similarly as the naive case. The difference is that during fit
+# baikal will detect and use the fit_predict method above.
+x = Input()
+y_t = Input()
+y_p1 = LogisticRegression(solver="liblinear", random_state=0)(
+    x, y_t, compute_func="predict_proba"
+)
+y_p2 = RandomForestClassifier(random_state=0)(x, y_t, compute_func="predict_proba")
+# predict_proba returns arrays whose columns sum to one, so we drop one column
+y_p1 = Lambda(lambda array: array[:, 1:])(y_p1)
+y_p2 = Lambda(lambda array: array[:, 1:])(y_p2)
+stacked_features = ColumnStack()([y_p1, y_p2])
+y_p = ExtraTreesClassifier(random_state=0)(stacked_features, y_t)
+
+model = Model(x, y_p, y_t)
+plot_model(model, filename="stacked_classifiers_standard.png", dpi=96)
+
+# ------- Train model
+model.fit(X_train, y_train)
+
+# ------- Evaluate model
+y_train_pred = model.predict(X_train)
+y_test_pred = model.predict(X_test)
+
+print("F1 score on train data:", f1_score(y_train, y_train_pred))
+print("F1 score on test data:", f1_score(y_test, y_test_pred))

--- a/tests/_core/test_model.py
+++ b/tests/_core/test_model.py
@@ -345,6 +345,22 @@ class TestFit:
         model.fit([iris.data, iris.data], [iris.target, iris.target])
         assert step.fitted_
 
+    def test_fit_compute(self, teardown):
+        dummy_estimator_1 = DummyEstimator()
+        dummy_estimator_2 = DummyEstimator()
+
+        x = Input()
+        y_t = Input()
+        y_p1 = dummy_estimator_1(x, y_t, fit_compute_func=None)
+        y_p2 = dummy_estimator_2(x, y_t)
+        model = Model(x, [y_p1, y_p2], y_t)
+        model.fit(iris.data, iris.target)
+
+        assert dummy_estimator_1.fit_calls == 1
+        assert dummy_estimator_1.fit_predict_calls == 0
+        assert dummy_estimator_2.fit_calls == 0
+        assert dummy_estimator_2.fit_predict_calls == 1
+
 
 class TestPredict:
     x1_data = iris.data[:, :2]
@@ -720,6 +736,9 @@ def test_fit_predict_naive_stack_with_proba_features(teardown):
     y_pred_traditional = stacked.predict(features)
 
     assert_array_equal(y_pred_baikal, y_pred_traditional)
+
+
+# TODO: Add test for fit_compute using a stack of classifiers
 
 
 @skip_sklearn_0_22

--- a/tests/_core/test_model.py
+++ b/tests/_core/test_model.py
@@ -774,8 +774,8 @@ def test_fit_predict_naive_stack_with_proba_features(teardown):
     y_p2 = RandomForestClassifier(n_estimators=n_estimators, random_state=random_state)(
         x, y_t, compute_func="apply"
     )
-    y_p1 = Lambda(compute_func=lambda array: array[:, :-1])(y_p1)
-    y_p2 = Lambda(compute_func=lambda array: array[:, :-1])(y_p2)
+    y_p1 = Lambda(compute_func=lambda array: array[:, 1:])(y_p1)
+    y_p2 = Lambda(compute_func=lambda array: array[:, 1:])(y_p2)
     features = Concatenate(axis=1)([y_p1, y_p2])
     y_p = LogisticRegression(random_state=random_state)(features, y_t)
 
@@ -795,7 +795,7 @@ def test_fit_predict_naive_stack_with_proba_features(teardown):
     random_forest_leafidx = random_forest.apply(x_data)
 
     features = np.concatenate(
-        [logreg_proba[:, :-1], random_forest_leafidx[:, :-1]], axis=1
+        [logreg_proba[:, 1:], random_forest_leafidx[:, 1:]], axis=1
     )
     stacked = sklearn.linear_model.LogisticRegression(random_state=random_state)
     stacked.fit(features, y_t_data)

--- a/tests/_core/test_model.py
+++ b/tests/_core/test_model.py
@@ -57,6 +57,11 @@ skip_sklearn_0_22 = pytest.mark.skipif(
     "see: https://github.com/scikit-learn/scikit-learn/issues/15845",
 )
 
+skip_sklearn_pre_0_22 = pytest.mark.skipif(
+    sklearn.__version__ < "0.22",
+    reason="StackingClassifier is not available prior to 0.22 ",
+)
+
 
 class TestInit:
     def test_simple(self, teardown):
@@ -696,6 +701,7 @@ def test_fit_predict_naive_stack(teardown):
     assert_array_equal(y_pred_baikal, y_pred_traditional)
 
 
+@skip_sklearn_pre_0_22
 def test_fit_predict_standard_stack(teardown):
     # This uses the "standard" protocol where the 2nd level features
     # are the out-of-fold predictions of the 1st. It also appends the

--- a/tests/_core/test_step.py
+++ b/tests/_core/test_step.py
@@ -63,7 +63,7 @@ class TestStep:
 
         with pytest.raises(ValueError):
             step = DummyStep()
-            step(x, compute_func=None)
+            step(x, compute_func="auto")
 
         with pytest.raises(ValueError):
             step = DummyStep()

--- a/tests/helpers/dummy_steps.py
+++ b/tests/helpers/dummy_steps.py
@@ -72,8 +72,24 @@ class _DummyEstimator(BaseEstimator):
     def __init__(self, x=123, y="abc"):
         self.x = x
         self.y = y
+        self.fit_calls = 0
+        self.fit_predict_calls = 0
 
     def predict(self, X):
+        return X
+
+    def predict_proba(self, X):
+        return X
+
+    def fit(self, X, y):
+        self.fit_calls += 1
+        return self
+
+    def fit_predict(self, X, y):
+        self.fit_predict_calls += 1
+        return X
+
+    def fit_predict_proba(self, X, y):
         return X
 
 

--- a/tests/helpers/sklearn_steps.py
+++ b/tests/helpers/sklearn_steps.py
@@ -2,12 +2,32 @@ import sklearn.decomposition
 import sklearn.ensemble
 import sklearn.linear_model
 import sklearn.preprocessing
+from sklearn.model_selection import cross_val_predict
 
 from baikal import make_step
 
+
+def _fit_predict_proba(self, X, y):
+    self.fit(X, y)
+    return cross_val_predict(self, X, y, method="predict_proba")
+
+
+def _fit_decision_function(self, X, y):
+    self.fit(X, y)
+    return cross_val_predict(self, X, y, method="decision_function")
+
+
 LinearRegression = make_step(sklearn.linear_model.LinearRegression)
 LogisticRegression = make_step(sklearn.linear_model.LogisticRegression)
+LinearSVC = make_step(sklearn.svm.LinearSVC)
+LinearSVCOOF = make_step(
+    sklearn.svm.LinearSVC, attr_dict={"fit_predict": _fit_decision_function}
+)
 RandomForestClassifier = make_step(sklearn.ensemble.RandomForestClassifier)
+RandomForestClassifierOOF = make_step(
+    sklearn.ensemble.RandomForestClassifier,
+    attr_dict={"fit_predict": _fit_predict_proba},
+)
 ExtraTreesClassifier = make_step(sklearn.ensemble.ExtraTreesClassifier)
 PCA = make_step(sklearn.decomposition.PCA)
 LabelEncoder = make_step(sklearn.preprocessing.LabelEncoder)


### PR DESCRIPTION
* Add new `fit_compute_func` to `Step.__call__` that allows to specify custom behavior at fit time.
* Add example of stacked classifiers that follow the standard protocol.
* Use `"auto"` to specify automatic detection of `compute_func` and `fit_compute_func`, reserve `None` to disable the `fit_compute_func`.
* Add capability of specifying extra attributes to classes created with `make_step` via a `attr_dict` argument. This is useful to add custom `fit_predict`/`fit_transform` methods.

The motivation follows the rationale in Issue #16:

1. Make custom fitting protocols, such as the common stacking protocol that uses out-of-fold predictions in the first level, possible. (The current stacked classifier example is a naive example that does not use OOF predictions and thus the second level classifier is prone to prefer an overfitted classifier from the first level).
2. Allow the use of transductive estimators (e.g. `sklearn.manifold.TSNE`, `sklearn.cluster.AgglomerativeClustering`).
3. Leverage estimators that implement a `fit_transform` more efficient than calling `fit` and `transform` separately.