### PR TITLE
[MAINT] Restore py35 CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,11 @@ build-defaults: &build-defaults
     - image: circleci/python:3.7.3-stretch
 
 jobs:
+  test-py35:
+    <<: *test-defaults
+    docker:
+      - image: circleci/python:3.5.7-stretch
+
   test-py36:
     <<: *test-defaults
     docker:
@@ -62,6 +67,11 @@ workflows:
   version: 2.1
   build-deploy:
     jobs:
+      - test-py35:
+          sklearn_version: *sklearn_version_prev
+      - test-py35:
+          sklearn_version: *sklearn_version_latest
+
       - test-py36:
           sklearn_version: *sklearn_version_prev
       - test-py36:
@@ -101,6 +111,8 @@ workflows:
               only:
                 - master
     jobs:
+      - test-py35:
+          sklearn_version: "nightly"
       - test-py36:
           sklearn_version: "nightly"
       - test-py37:

--- a/baikal/_core/step.py
+++ b/baikal/_core/step.py
@@ -496,7 +496,7 @@ class Step(_StepBase):
         *,
         compute_func: Union[str, Callable[..., Any]] = "auto",
         fit_compute_func: Optional[Union[str, Callable[..., Any]]] = "auto",
-        trainable: bool = True,
+        trainable: bool = True
     ) -> Union[DataPlaceholder, List[DataPlaceholder]]:
         """Call the step on input(s) (from previous steps) and generates the
         output(s) to be used in further steps.

--- a/baikal/steps/expression.py
+++ b/baikal/steps/expression.py
@@ -69,7 +69,7 @@ class Lambda(Step):
         *,
         compute_func: Union[str, Callable[..., Any]] = "auto",
         fit_compute_func: Optional[Union[str, Callable[..., Any]]] = "auto",
-        trainable: bool = True,
+        trainable: bool = True
     ) -> Union[DataPlaceholder, List[DataPlaceholder]]:
         """Call the step on input(s) (from previous steps) and generates the
         output(s) to be used in further steps.


### PR DESCRIPTION
Actually support for python 3.5 was broken due to trailing commas in a couple of `def`s.