### PR TITLE
Fix bug where get_params could not resolve base classes without __init__

### DIFF
--- a/baikal/_core/step.py
+++ b/baikal/_core/step.py
@@ -38,14 +38,20 @@ class _StepBase:
         # For testing purposes only.
         cls._names.clear()
 
-    def _get_param_names(self):
+    @classmethod
+    def _get_param_names(cls):
         """This is a workaround to override @classmethod binding of the sklearn
         parent class method so we can feed it the sklearn parent class instead
         of the children class. We assume client code subclassed from this mixin
         and a sklearn class, with the sklearn class being the next base class in
         the mro.
         """
-        return super()._get_param_names.__func__(super())
+        mro = cls.mro()
+        for super_class in mro[mro.index(_StepBase) + 1 :]:
+            if hasattr(super_class, "__init__"):
+                # object is the last class in the mro and it defines an __init__ method
+                # so this is guaranteed to return before the for loop finishes
+                return super()._get_param_names.__func__(super_class)
 
     def _get_step_attr(self, attr):
         n_nodes = len(self._nodes)

--- a/tests/_core/test_step.py
+++ b/tests/_core/test_step.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from functools import partial
 
 import pytest
+from sklearn.base import TransformerMixin, BaseEstimator
 
 from baikal import Input, Step
 from baikal._core.data_placeholder import DataPlaceholder
@@ -220,6 +221,21 @@ class TestStep:
         params = step.get_params()
         expected = {"x": 123, "y": "abc"}
         assert params == expected
+
+    def test_get_params_without_init(self, teardown):
+        """Test edge case where the base class does not define
+        an __init__ method. get_params should resolve to object.__init__
+        which results in an empty dict.
+        """
+
+        class TransformerWithoutInit(TransformerMixin, BaseEstimator):
+            pass
+
+        class TransformerWithoutInitStep(Step, TransformerWithoutInit):
+            pass
+
+        step = TransformerWithoutInitStep()
+        assert step.get_params() == {}
 
     def test_set_params(self, teardown):
         step = DummyEstimator()


### PR DESCRIPTION
Fixes #31.