### PR TITLE
[ENH, BUGFIX] Add class_name arg to make_step and fix missing *args bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3.7

--- a/baikal/_core/step.py
+++ b/baikal/_core/step.py
@@ -415,8 +415,8 @@ class Step(_StepBase):
         import sklearn.linear_model
         # The order of inheritance is important!
         class LogisticRegression(Step, sklearn.linear_model.LogisticRegression):
-            def __init__(self, name=None, **kwargs):
-                super().__init__(name=name, **kwargs)
+            def __init__(self, *args, name=None, **kwargs):
+                super().__init__(*args, name=name, **kwargs)
 
         logreg = LogisticRegression(C=2.0)
 

--- a/baikal/steps/factory.py
+++ b/baikal/steps/factory.py
@@ -5,12 +5,12 @@ import inspect
 from baikal.steps import Step
 
 
-def make_step(base_class, attr_dict=None):
+def make_step(base_class, class_name=None, attr_dict=None):
     """Creates a step subclass from the given base class.
 
     For example, calling::
 
-        PCA = make_step(sklearn.decomposition.PCA)
+        PCA = make_step(sklearn.decomposition.PCA, class_name="PCA")
 
     is equivalent to::
 
@@ -22,6 +22,10 @@ def make_step(base_class, attr_dict=None):
     ----------
     base_class : type
         The base class to inherit from. It must implement the scikit-learn API.
+
+    class_name
+        Name of the step class. If None, the name will be the name of the given
+        base class.
 
     attr_dict : dict
         Dictionary of additional attributes for the class. You can use this to add
@@ -42,7 +46,7 @@ def make_step(base_class, attr_dict=None):
         )
 
     metaclass = type(base_class)
-    name = base_class.__name__
+    name = base_class.__name__ if class_name is None else class_name
     bases = (Step, base_class)
     caller_module = inspect.currentframe().f_back.f_globals["__name__"]
 

--- a/baikal/steps/factory.py
+++ b/baikal/steps/factory.py
@@ -1,3 +1,6 @@
+from types import FrameType
+from typing import Optional, Dict, Any, cast
+
 __all__ = ["make_step"]
 
 import inspect
@@ -5,7 +8,9 @@ import inspect
 from baikal.steps import Step
 
 
-def make_step(base_class, class_name=None, attr_dict=None):
+def make_step(
+    base_class: type, class_name: Optional[str] = None, attr_dict: Dict[str, Any] = None
+) -> type:
     """Creates a step subclass from the given base class.
 
     For example, calling::
@@ -20,21 +25,21 @@ def make_step(base_class, class_name=None, attr_dict=None):
 
     Parameters
     ----------
-    base_class : type
+    base_class
         The base class to inherit from. It must implement the scikit-learn API.
 
     class_name
         Name of the step class. If None, the name will be the name of the given
         base class.
 
-    attr_dict : dict
+    attr_dict
         Dictionary of additional attributes for the class. You can use this to add
         methods such as ``fit_compute`` to the class. (keys: name of attribute (``str``),
         values: attributes).
 
     Returns
     -------
-    step_subclass : type
+    step_subclass
         A new class that inherits from both Step and the given base class and has the
         the specified attributes.
 
@@ -48,7 +53,8 @@ def make_step(base_class, class_name=None, attr_dict=None):
     metaclass = type(base_class)
     name = base_class.__name__ if class_name is None else class_name
     bases = (Step, base_class)
-    caller_module = inspect.currentframe().f_back.f_globals["__name__"]
+    caller_frame = cast(FrameType, cast(FrameType, inspect.currentframe()).f_back)
+    caller_module = caller_frame.f_globals["__name__"]
 
     dict = {"__init__": __init__, "__module__": caller_module}
     if attr_dict is not None:

--- a/baikal/steps/factory.py
+++ b/baikal/steps/factory.py
@@ -20,8 +20,8 @@ def make_step(
     is equivalent to::
 
         class PCA(Step, sklearn.decomposition.PCA):
-            def __init__(self, name=None, n_outputs=1, **kwargs):
-                super().__init__(name=name, n_outputs=n_outputs, **kwargs)
+            def __init__(self, *args, name=None, n_outputs=1, **kwargs):
+                super().__init__(*args, name=name, n_outputs=n_outputs, **kwargs)
 
     Parameters
     ----------
@@ -45,9 +45,9 @@ def make_step(
 
     """
 
-    def __init__(self, name=None, n_outputs=1, **kwargs):
+    def __init__(self, *args, name=None, n_outputs=1, **kwargs):
         super(self.__class__, self).__init__(
-            name=name, n_outputs=n_outputs, **kwargs,
+            *args, name=name, n_outputs=n_outputs, **kwargs,
         )
 
     metaclass = type(base_class)

--- a/docs/src/user_guide.rst
+++ b/docs/src/user_guide.rst
@@ -108,8 +108,8 @@ For example, to make a step for ``sklearn.linear_model.LogisticRegression`` we d
 
     # The order of inheritance is important!
     class LogisticRegression(Step, sklearn.linear_model.LogisticRegression):
-        def __init__(self, name=None, n_outputs=1, **kwargs):
-            super().__init__(name=name,n_outputs=n_outputs,**kwargs)
+        def __init__(self, *args, name=None, n_outputs=1, **kwargs):
+            super().__init__(*args, name=name,n_outputs=n_outputs,**kwargs)
 
 Other steps are defined similarly (omitted here for brevity).
 

--- a/tests/steps/test_factory.py
+++ b/tests/steps/test_factory.py
@@ -1,14 +1,24 @@
+import pytest
 import sklearn.linear_model
 
 from baikal import make_step, Step
 
 
-def test_make_step():
+@pytest.mark.parametrize(
+    "class_name,expected",
+    [
+        (None, "LogisticRegression"),
+        ("LogisticRegressionStep", "LogisticRegressionStep"),
+    ],
+)
+def test_make_step(class_name, expected):
     def some_method(self):
         pass
 
     LogisticRegression = make_step(
-        sklearn.linear_model.LogisticRegression, attr_dict={"some_method": some_method}
+        sklearn.linear_model.LogisticRegression,
+        class_name,
+        {"some_method": some_method},
     )
 
     assert issubclass(LogisticRegression, Step)
@@ -18,4 +28,4 @@ def test_make_step():
     assert hasattr(LogisticRegression, "fit")
     assert hasattr(LogisticRegression, "predict")
     assert hasattr(LogisticRegression, "some_method")
-    assert LogisticRegression.__name__ == "LogisticRegression"
+    assert LogisticRegression.__name__ == expected


### PR DESCRIPTION
- Add capability to specify a name to the class made by `make_step`.
- Fix bug where `*args` was not included in the constructor of the class made by `make_step` (and fix related examples in the docs).
- Add typing.