### PR TITLE
Add deprecation warning to default value of class_name argument of make_step

### DIFF
--- a/baikal/steps/factory.py
+++ b/baikal/steps/factory.py
@@ -1,3 +1,4 @@
+import warnings
 from types import FrameType
 from typing import Optional, Dict, Any, cast
 
@@ -35,7 +36,11 @@ def make_step(
 
     class_name
         Name of the step class. If None, the name will be the name of the given
-        base class.
+        base class. For instances made from the generated class to be pickle-able,
+        you must pass a name that matches the name of the variable the generated
+        class is being assigned to (the variable must also be declared at the top
+        level of the module). **Deprecation notice**: This argument will be required
+        from version 0.5.0.
 
     Returns
     -------
@@ -51,7 +56,15 @@ def make_step(
         )
 
     metaclass = type(base_class)
-    name = base_class.__name__ if class_name is None else class_name
+    if class_name is None:
+        warnings.warn(
+            "Pass a string to `class_name`. From version 0.5.0 this argument will be"
+            " required.",
+            FutureWarning,
+        )
+        name = base_class.__name__
+    else:
+        name = class_name
     bases = (Step, base_class)
     caller_frame = cast(FrameType, cast(FrameType, inspect.currentframe()).f_back)
     caller_module = caller_frame.f_globals["__name__"]

--- a/tests/steps/test_factory.py
+++ b/tests/steps/test_factory.py
@@ -1,25 +1,33 @@
+from contextlib import contextmanager
+
 import pytest
 import sklearn.linear_model
 
 from baikal import make_step, Step
 
 
+@contextmanager
+def does_not_warn():
+    yield
+
+
 @pytest.mark.parametrize(
-    "class_name,expected",
+    "class_name,expected,warns",
     [
-        (None, "LogisticRegression"),
-        ("LogisticRegressionStep", "LogisticRegressionStep"),
+        (None, "LogisticRegression", pytest.warns(FutureWarning)),
+        ("LogisticRegressionStep", "LogisticRegressionStep", does_not_warn()),
     ],
 )
-def test_make_step(class_name, expected):
+def test_make_step(class_name, expected, warns):
     def some_method(self):
         pass
 
-    LogisticRegression = make_step(
-        sklearn.linear_model.LogisticRegression,
-        {"some_method": some_method},
-        class_name,
-    )
+    with warns:
+        LogisticRegression = make_step(
+            sklearn.linear_model.LogisticRegression,
+            {"some_method": some_method},
+            class_name,
+        )
 
     assert issubclass(LogisticRegression, Step)
     assert issubclass(LogisticRegression, sklearn.linear_model.LogisticRegression)


### PR DESCRIPTION
The default value of `None` is planned to be deprecated from version 0.5.0. This is to encourage setting `class_name` to the same name of the variable the generated class is being assigned to and avoid pickling issues like the one in #42.

Usages of `make_step` in the tests and examples are left as-is for the moment. They will be revised when the signature of `make_step` is revised to make `class_name` a required argument (backwards-incompatible change).