### PR TITLE
Fix bug where the tar.gz file with the source code was not being uploaded to PyPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
           root: ./dist
           paths:
             - "*.whl"
+            - "*.tar.gz"
       - store_artifacts:
           path: ./dist
 


### PR DESCRIPTION
Addresses the issue mentioned [here](https://github.com/alegonz/baikal/issues/47#issuecomment-812810535).

TODO: check it works once PyPI becomes available.